### PR TITLE
Add Android 14 notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ npm install
 npm start
 ```
 
+**Atenção:** versões do Android 14 (API 34) apresentam erro ao iniciar o app
+devido à permissão `DETECT_SCREEN_CAPTURE`. Utilize um emulador ou aparelho
+com Android 13 ou anterior, ou atualize o Expo/React Native quando houver
+correção oficial.
+
 
 ```bash
 docker compose build --no-cache

--- a/app.json
+++ b/app.json
@@ -12,6 +12,9 @@
     },
     "assetBundlePatterns": [
       "**/*"
-    ]
+    ],
+    "android": {
+      "permissions": ["android.permission.DETECT_SCREEN_CAPTURE"]
+    }
   }
 }

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -10,6 +10,10 @@ npm install
 npm start
 ```
 
+Em aparelhos com Android 14 (API 34) o app falha ao iniciar por exigir a
+permissão privilegiada `DETECT_SCREEN_CAPTURE`. Utilize Android 13 ou
+anterior, ou aguarde uma correção das dependências do Expo/React Native.
+
 O app inclui telas de cadastro/login, agendamento de consultas, envio de documentos e chat de suporte com IA (simulado).
 
 ## Com Docker

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -12,6 +12,9 @@
     },
     "assetBundlePatterns": [
       "**/*"
-    ]
+    ],
+    "android": {
+      "permissions": ["android.permission.DETECT_SCREEN_CAPTURE"]
+    }
   }
 }


### PR DESCRIPTION
## Summary
- mention Android 14 permission issue in README files
- request `DETECT_SCREEN_CAPTURE` permission in app configs

## Testing
- `npm test` *(fails: Missing script)*
- `cd mobile && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684885fc37d0832586048640778c8939